### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/prwork8101999/832f7329-2570-4ac3-8f97-df10ff88da68/1504afc9-ef2c-4398-8407-a0f2c560694d/_apis/work/boardbadge/6b897f9a-b0cc-4185-9594-1680489452c1)](https://dev.azure.com/prwork8101999/832f7329-2570-4ac3-8f97-df10ff88da68/_boards/board/t/1504afc9-ef2c-4398-8407-a0f2c560694d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#12](https://dev.azure.com/prwork8101999/832f7329-2570-4ac3-8f97-df10ff88da68/_workitems/edit/12). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.